### PR TITLE
Dirty Flag Chapter: Fix a typo in one of the asides

### DIFF
--- a/book/dirty-flag.markdown
+++ b/book/dirty-flag.markdown
@@ -183,7 +183,7 @@ Editors that auto-save a backup in the background are compensating specifically 
 
 <aside name="gc">
 
-This is mirrors the different garbage collection strategies in systems that automatically manage memory. Reference counting frees memory the second it's no longer needed, but burns CPU time updating ref counts eagerly every time references are changed.
+This mirrors the different garbage collection strategies in systems that automatically manage memory. Reference counting frees memory the second it's no longer needed, but burns CPU time updating ref counts eagerly every time references are changed.
 
 Simple garbage collectors defer reclaiming memory until it's really needed, but the cost is the dreaded "GC pause" that can freeze your entire game until the collector is done scouring the heap.
 


### PR DESCRIPTION
I have fixed a typo in the Dirty Flag chapter. I made this a pull request, so hopefully you can merge it directly without having to search for the mistake.
