### PR TITLE
Changing Singleton Implementation

### DIFF
--- a/code/cpp/singleton.h
+++ b/code/cpp/singleton.h
@@ -9,9 +9,9 @@ namespace Singleton1
     static FileSystem& instance()
     {
       // Lazy initialize.
-      static FileSystem *instance_ = new FileSystem();
+      static FileSystem *instance = new FileSystem();
 
-      return *instance_;
+      return *instance;
     }
 
   private:
@@ -122,12 +122,12 @@ namespace Singleton3
   IFileSystem& IFileSystem::instance()
   {
     #if PLATFORM == PLAYSTATION3
-      static IFileSystem *instance_ = new PS3FileSystem();
+      static IFileSystem *instance = new PS3FileSystem();
     #elif PLATFORM == WII
-      static IFileSystem *instance_ = new WiiFileSystem();
+      static IFileSystem *instance = new WiiFileSystem();
     #endif
 
-    return *instance_;
+    return *instance;
   }
   //^4
 }


### PR DESCRIPTION
Changing to Meyer's Singleton Implementation as it's also lazy initialized but simpler and thread-safe as guaranteed by C++ standard since C++11 ( §6.7 [stmt.dcl] p4 ).
