### PR TITLE
Update game-loop.markdown

### DIFF
--- a/book/game-loop.markdown
+++ b/book/game-loop.markdown
@@ -675,5 +675,5 @@ Russell and co. managed to create Spacewar! on it.
     runner-up.
 
  *  The [Unity](http://unity3d.com/) framework has a complex game loop, detailed
-    in a wonderful illustration [here](http://www.richardfine.co.uk/2012/10/unit
-    y3d-monobehaviour-lifecycle/).
+    in a wonderful illustration [here
+    ](http://www.richardfine.co.uk/2012/10/unity3d-monobehaviour-lifecycle/).


### PR DESCRIPTION
Link failure caused by newline and spacing
