### PR TITLE
Fix unity "UsingComponents" link

### DIFF
--- a/book/component.markdown
+++ b/book/component.markdown
@@ -667,7 +667,7 @@ communication paths if you need them.
 ## See Also
 
  *  The [Unity](http://unity3d.com) framework's core [`GameObject`](http://docs.unity3d.com/Documentation/Manual/GameObjects.html) class is designed
-    entirely around [components](http://docs.unity3d.com/Documentation/Manual/UsingComponents40.html).
+    entirely around [components](http://docs.unity3d.com/Manual/UsingComponents.html).
 
  *  The open source [Delta3D](http://www.delta3d.org) engine has a base
     `GameActor` class that implements this pattern with the appropriately named


### PR DESCRIPTION
Apparantly, this page has moved. I just changed the link to the new location.